### PR TITLE
Добавил кастомные проверки входных данных для АПИ-методов

### DIFF
--- a/lib/docsValidator.d.ts
+++ b/lib/docsValidator.d.ts
@@ -11,6 +11,7 @@ interface ParameterDetail {
     type: string;
     description: string;
     required: boolean;
+    validators?: ValidationRule[];
 }
 interface Parameters<T> {
     example: T;
@@ -20,6 +21,7 @@ interface Parameters<T> {
     header_params: ParameterDetail[];
     checks: ((obj: T) => Promise<boolean>)[];
 }
+declare type ValidationRule = (valueToValidate: any) => boolean;
 export declare class ApiHelper {
     app: any;
     documentationPaths: any;

--- a/lib/docsValidator.js
+++ b/lib/docsValidator.js
@@ -33,10 +33,15 @@ function validateAny(value) {
 function validateBoolean(value) {
     return { ok: ((value + '') == 'true') || ((value + '') == 'false'), value: (value + '') == 'true' };
 }
-function validate(value, type) {
+function validate(value, type, rules) {
     const validations = { 'number': validateNumber, 'string': validateString, 'boolean': validateBoolean, 'any': validateAny };
     if (type in validations) {
-        return validations[type](value);
+        if (!rules) {
+            return validations[type](value);
+        }
+        else {
+            return { ok: rules === null || rules === void 0 ? void 0 : rules.every(validatingFunction => validatingFunction(value) === true), value: value };
+        }
     }
     return { ok: false, value: null };
 }
@@ -158,7 +163,7 @@ class ApiHelper {
                 }
                 for (i in collected_params) {
                     let param = collected_params[i];
-                    let validation = validate(param.value, param.detail.type);
+                    let validation = validate(param.value, param.detail.type, param.detail.validators);
                     if (!validation.ok) {
                         return res.json({ ok: false, error: 'invalid_param', name: param.detail.name, type: param.detail.type });
                     }


### PR DESCRIPTION
Теперь их можно описывать прямо при написании API продуктов и валидировать свои собственные типы данных, например JSON'ы, чтобы гарантировать правильность их формы