### PR TITLE
Refactor logEvent to handle nested objects correctly

### DIFF
--- a/lib/log.d.ts
+++ b/lib/log.d.ts
@@ -46,9 +46,7 @@ export declare enum Severity {
     Debug = "debug"
 }
 export declare let logException: (topic: Topic, severity: Severity, exception: Error, subtopic?: SubTopic) => void;
-export declare function logEvent(topic: string, severity: Severity, obj: {
-    [key: string]: string | number;
-}, subtopic?: SubTopic): void;
+export declare function logEvent(topic: string, severity: Severity, obj: any, subtopic?: SubTopic): void;
 export declare function logMessage(topic: string, severity: Severity, message: string, subtopic?: SubTopic): void;
 export declare function logObject(topic: Topic, severity: Severity, logObj: {
     [index: string]: any;

--- a/lib/log.js
+++ b/lib/log.js
@@ -73,14 +73,16 @@ function makeFlatObject(obj) {
         }
         const result = {};
         for (const [key, value] of Object.entries(obj)) {
-            if (!constants_1.is_dev_env) {
-                if (process.env.is_running_tests)
-                    return;
+            if (!constants_1.is_dev_env && process.env.is_running_tests)
+                return;
+            if (typeof value == 'object') {
+                const flattenedValue = makeFlatObject(value);
+                for (const [extendedKey, extendedValue] of Object.entries(flattenedValue)) {
+                    result[key + '_' + extendedKey] = extendedValue;
+                }
+            }
+            else
                 result[key] = `${value}`;
-            }
-            else {
-                result[key] = `${value}\n`;
-            }
         }
         return result;
     }

--- a/src/log.ts
+++ b/src/log.ts
@@ -73,12 +73,14 @@ function makeFlatObject(obj: any) {
         }
         const result: any = {};
         for (const [key, value] of Object.entries(obj)) {
-            if (!is_dev_env) {
-                if (process.env.is_running_tests) return;
-                result[key] = `${value}`;
-            } else {
-                result[key] = `${value}\n`;
+            if (!is_dev_env && process.env.is_running_tests) return;
+            if (typeof value == 'object') {
+                const flattenedValue=makeFlatObject(value);
+                for (const [extendedKey, extendedValue] of Object.entries(flattenedValue)){
+                    result[key+'_'+extendedKey]=extendedValue;
+                }
             }
+            else result[key] = `${value}`;
         }
         return result;
     } catch (e) {
@@ -108,7 +110,7 @@ export let logException = function (topic: Topic, severity: Severity, exception:
     }
 };
 
-export function logEvent(topic: string, severity: Severity, obj: { [key: string]: string | number }, subtopic = SubTopic.Unknown) {
+export function logEvent(topic: string, severity: Severity, obj: any, subtopic = SubTopic.Unknown) {
     try {
         if (!is_dev_env) {
             if (process.env.is_running_tests) return;


### PR DESCRIPTION
The logEvent function in the log.ts module has been refactored to handle nested objects correctly.