### PR TITLE
Refactor object flattening logic

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -72,7 +72,7 @@ function makeFlatObject(obj) {
             return { value: obj };
         }
         const result = {};
-        for (const [key, value] of Object.entries(obj)) {
+        for (const [key, value] of Object.entries(obj !== null && obj !== void 0 ? obj : {})) {
             if (!constants_1.is_dev_env && process.env.is_running_tests)
                 return;
             if (typeof value == 'object') {

--- a/src/log.ts
+++ b/src/log.ts
@@ -72,7 +72,7 @@ function makeFlatObject(obj: any) {
             return { value: obj };
         }
         const result: any = {};
-        for (const [key, value] of Object.entries(obj)) {
+        for (const [key, value] of Object.entries(obj ?? {})) {
             if (!is_dev_env && process.env.is_running_tests) return;
             if (typeof value == 'object') {
                 const flattenedValue=makeFlatObject(value);


### PR DESCRIPTION
Refactor the object flattening logic in the `makeFlatObject` function to handle null or undefined input objects gracefully. This prevents the function from returning undefined values in certain cases.